### PR TITLE
As we do in rails there is no need to create separate db role

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -52,8 +52,6 @@ config :phoenix, :stacktrace_depth, 20
 # Configure your database
 config :eliscore, Eliscore.Repo,
   adapter: Ecto.Adapters.Postgres,
-  username: "eliscore",
-  password: "eliscore",
   database: "eliscore_dev",
   hostname: "localhost",
   pool_size: 10


### PR DESCRIPTION
database ymls for most of projects dont't require to setup separate user
just uses default ones

Yup, during setup I didn't want to create separate role for this app... laziness